### PR TITLE
Simplify package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,19 +1,6 @@
 {
-  "name": "tibia-highscores",
-  "version": "1.0.0",
-  "description": "",
-  "main": "fetch.mjs",
+  "private": true,
   "scripts": {
     "fetch": "node fetch.mjs"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/LeeKunTibia/tibia-highscores.git"
-  },
-  "author": "Lee kun",
-  "license": "ISC",
-  "bugs": {
-    "url": "https://github.com/LeeKunTibia/tibia-highscores/issues"
-  },
-  "homepage": "https://github.com/LeeKunTibia/tibia-highscores#readme"
+  }
 }


### PR DESCRIPTION
Since we're not publishing tibia-highscores as a package to npm, we can mark it as private and remove all unneeded metadata.