### PR TITLE
Update max charm points

### DIFF
--- a/fetch.mjs
+++ b/fetch.mjs
@@ -7,7 +7,7 @@ const maxPoints = [
 	// Achievements.
 	1302, // TODO: Add points for "The Rule of Raccool" once known.
 	// Charm Points.
-	24275,
+	24305,
 	// Boss Points.
 	24950,
 ];


### PR DESCRIPTION
Two new Easy creatures (“rabid wolf” and “ragged rabid wolf”) were introduced a while ago, yielding 15 points for 500 kills each. Thus,

    MAX_CHARM_POINTS += 30

https://www.tibia.com/news/?subtopic=newsarchive&id=7720